### PR TITLE
fixed dependency in config files

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -277,6 +277,8 @@ class nagios::server (
         owner => 'root',
         group => 'nagios',
         mode  => '0640',
+	ensure => present,
+	before => Service[nagios],
     }
 
     # Nagios commands


### PR DESCRIPTION
Files need to be ready (and with right perms) before service restart.

I also put ensure=>present because if there is no nagios_host.cfg (server not configured as a client) file, nagios won't boot, and that's not ok. Besides, having empty files does not hurt. If server is required to be client, there should be an automatic include... but it's probably better this way.
