### PR TITLE
added dependency for selinux module

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -6,3 +6,4 @@ license 'Apache 2.0'
 summary 'Nagios client and server module'
 description "Install and configure one or more nagios servers to monitor all of your puppet-managed nodes."
 project_page 'https://github.com/thias/puppet-nagios'
+dependency 'thias-selinux'


### PR DESCRIPTION
If selinux is set to enforced, puppet-nagios would need thias-selinux module as dependency. Otherwise it puppet would dump following. 

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Puppet::Parser::AST::Resource failed with error ArgumentError: Invalid resource type selinux::audit2allow at /etc/puppet/environments/production/modules/nagios/manifests/server.pp:685 on node xxx.pythian.com
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```
