### PR TITLE
allow specifying a megacli version to pin

### DIFF
--- a/manifests/check/megaraid_sas.pp
+++ b/manifests/check/megaraid_sas.pp
@@ -2,7 +2,7 @@ define nagios::check::megaraid_sas (
     $ensure = undef,
     $args = '',
     $pkg = true,
-    $megaclibin = $::nagios::params::megaclibin
+    $megaclibin = $::nagios::params::megaclibin,
 ) {
 
     # Generic overrides
@@ -43,10 +43,15 @@ define nagios::check::megaraid_sas (
             'Gentoo' => 'sys-block/megacli',
              default => 'megacli',
         }
+        if $::nagios_check_megaraid_sas_version != '' {
+          $ensure_value = $::nagios_check_megaraid_sas_version
+        } else {
+          $ensure_value = 'installed'
+        }
         package { $pkgname:
             ensure => $ensure ? {
                 'absent' => 'absent',
-                 default => 'installed',
+                 default => $ensure_value
             }
         }
     }


### PR DESCRIPTION
I needed a way to get a lower-version megacli installed because versions above 8.00.29 provoke an increase of 'Other Errors' by 1 every time it is run, rendering the nagios checks useless to me otherwise.
