### PR TITLE
Can set replace=false for htpasswd file via nagios::server parameter.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -21,6 +21,7 @@ class nagios::server (
   $apache_httpd_conf_source     = undef,
   $apache_allowed_from          = [],   # Allow access in default template
   $apache_httpd_htpasswd_source = "puppet:///modules/${module_name}/apache_httpd/htpasswd",
+  $htpasswd_replace = true,
   $php     = true,
   $php_apc = true,
   # cgi.cfg
@@ -190,6 +191,7 @@ class nagios::server (
       owner   => 'root',
       group   => 'apache',
       mode    => '0640',
+      replace => $htpasswd_replace,
       source  => $apache_httpd_htpasswd_source,
       require => Package['nagios'],
     }


### PR DESCRIPTION
I'm aware I can specify a different htpasswd source file but that might mean we would need to maintain many of these, which isn't desirable for my organization.  This way we can make local changes to the htpasswd file for different deployments/installations and don't need extra puppet runs to apply them either.