### PR TITLE
ensure processorcount fact value is a number, to keep puppet 3.7.4 happy

### DIFF
--- a/manifests/check/load.pp
+++ b/manifests/check/load.pp
@@ -17,11 +17,12 @@ class nagios::check::load (
 
   # We choose defaults based on the number of CPU cores.
   if $args == undef {
-    if ( $::processorcount > 16 ) {
+    $processorcount_int = $::processorcount + 0
+    if ( $processorcount_int > 16 ) {
       $final_args = '-w 60,40,40 -c 90,70,70'
-    } elsif ( $::processorcount > 8 ) and ( $::processorcount <= 16 ) {
+    } elsif ( $processorcount_int > 8 ) and ( $processorcount_int <= 16 ) {
       $final_args = '-w 25,20,20 -c 40,35,35'
-    } elsif ( $::processorcount > 4 ) and ( $::processorcount <= 8 ) {
+    } elsif ( $processorcount_int > 4 ) and ( $processorcount_int <= 8 ) {
       $final_args = '-w 20,15,15 -c 35,30,30'
     } else {
       $final_args = '-w 15,10,10 -c 30,25,25'


### PR DESCRIPTION
Before this change, I get the following error message:

```
Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Comparison of: String > Integer, is not possible. Caused by 'A String is not comparable to a non String'. at /path/to/modules/nagios/manifests/check/load.pp:20:28 on node host.fqdn
```

probably related to / introduced by:
https://tickets.puppetlabs.com/browse/PUP-3615