### PR TITLE
Support Ubuntu for nrpe

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,7 +77,7 @@ class nagios::params {
         tag    => $nagios_plugins_packages,
       }
     }
-    'Debian': {
+    'Debian', 'Ubuntu': {
       $nrpe_package       = [ 'nagios-nrpe-server' ]
       $nrpe_package_alias = 'nrpe'
       $nrpe_service       = 'nagios-nrpe-server'


### PR DESCRIPTION
Was able to install using the nrpe client on Ubuntu with this change.