### PR TITLE
Allow setting debug parameter through nrpe.cfg template

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -15,6 +15,7 @@ class nagios::client (
   $nrpe_allowed_hosts          = '127.0.0.1',
   $nrpe_dont_blame_nrpe        = '0',
   $nrpe_command_prefix         = undef,
+  $nrpe_debug                  = 0,
   $nrpe_command_timeout        = '60',
   $nrpe_connection_timeout     = '300',
   # host defaults

--- a/templates/nrpe.cfg.erb
+++ b/templates/nrpe.cfg.erb
@@ -132,7 +132,7 @@ command_prefix=<%= @nrpe_command_prefix %>
 # syslog facility.
 # Values: 0=debugging off, 1=debugging on
 
-debug=0
+debug=<%= @nrpe_debug %>
 
 
 


### PR DESCRIPTION
All other settings in current template are parametrized.

I would like to have ability to set the debug through the class parameter, rather than hacking around.