### PR TITLE
Add cfg_append hash for nagios.cfg

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -62,6 +62,7 @@ class nagios::server (
   $date_format = 'iso8601',
   $admin_email = 'root@localhost',
   $admin_pager = 'pagenagios@localhost',
+  $cfg_append  = undef,
   # private/resource.cfg for $USERx$ macros (from 1 to 32)
   $user = {
     '1' => $::nagios::params::plugin_dir,
@@ -208,6 +209,9 @@ class nagios::server (
   }
 
   # Configuration files
+  if ($cfg_append != undef) {
+    validate_hash($cfg_append)
+  }
   file { '/etc/nagios/cgi.cfg':
     owner   => 'root',
     group   => 'root',
@@ -715,4 +719,3 @@ class nagios::server (
   # lint:endignore
 
 }
-

--- a/templates/nagios.cfg.erb
+++ b/templates/nagios.cfg.erb
@@ -1344,3 +1344,8 @@ debug_file=/var/log/nagios/nagios.debug
 max_debug_file_size=1000000
 
 
+<% if @cfg_append -%>
+  <%- @cfg_append.sort_by{ |k, v| }.each do |key,value| -%>
+<%= key %>=<%= value %>
+  <%- end -%>
+<% end -%>


### PR DESCRIPTION
I needed to add `allow_empty_hostgroup_assignment=1` to the `nagios.cfg` configuration file, and I thought this would be a much better way to add additional nagios server parameters versus you having to deal with an un-ending barrage of pull requests adding each specific server parameters.

I didn't write any documentation in the README because there didn't seem like a good place to do that, but I certainly can if you want me to add that.