### PR TITLE
Decouple management of Apache virtual host

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -166,38 +166,38 @@ class nagios::server (
     require   => Package['nagios'],
   }
 
-  # Set a default content template if no content/source is specified
-  if $apache_httpd_conf_source == undef {
-    if $apache_httpd_conf_content == undef {
-      $apache_httpd_conf_content_final = template("${module_name}/apache_httpd/httpd-nagios.conf.erb")
-    } else {
-      $apache_httpd_conf_content_final = $apache_httpd_conf_content
-    }
-  }
-  file { '/etc/httpd/conf.d/nagios.conf':
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    content => $apache_httpd_conf_content_final,
-    source  => $apache_httpd_conf_source,
-    notify  => Service['httpd'],
-    require => Package['nagios'],
-  }
-  if $apache_httpd_htpasswd_source != false {
-    file { '/etc/nagios/.htpasswd':
-      owner   => 'root',
-      group   => 'apache',
-      mode    => '0640',
-      source  => $apache_httpd_htpasswd_source,
-      require => Package['nagios'],
-    }
-  }
-
   if $apache_httpd {
     class { '::apache_httpd':
       ssl       => $apache_httpd_ssl,
       modules   => $apache_httpd_modules,
       keepalive => 'On',
+    }
+
+    # Set a default content template if no content/source is specified
+    if $apache_httpd_conf_source == undef {
+      if $apache_httpd_conf_content == undef {
+        $apache_httpd_conf_content_final = template("${module_name}/apache_httpd/httpd-nagios.conf.erb")
+      } else {
+        $apache_httpd_conf_content_final = $apache_httpd_conf_content
+      }
+    }
+    file { '/etc/httpd/conf.d/nagios.conf':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => $apache_httpd_conf_content_final,
+      source  => $apache_httpd_conf_source,
+      notify  => Service['httpd'],
+      require => Package['nagios'],
+    }
+    if $apache_httpd_htpasswd_source != false {
+      file { '/etc/nagios/.htpasswd':
+        owner   => 'root',
+        group   => 'apache',
+        mode    => '0640',
+        source  => $apache_httpd_htpasswd_source,
+        require => Package['nagios'],
+      }
     }
   }
 


### PR DESCRIPTION
This is a just a port of @alexharv074 suggested patch to properly allow
the user to manage the http configuration.

Issue: thias/puppet-nagios#31