### PR TITLE
Disable the swap check if swap size equals zero.

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -145,7 +145,10 @@ class nagios::client (
     class { '::nagios::check::ping': }
     class { '::nagios::check::ping6': }
     class { '::nagios::check::ram': }
-    class { '::nagios::check::swap': }
+    # Enable check_swap only if swap is enabled
+    if $::swapsize_mb != '0.00' {
+      class { '::nagios::check::swap': }
+    }
     # Conditional ones, once presence is detected using our custom facts
     if $::nagios_couchbase {        class { '::nagios::check::couchbase': } }
     if $::nagios_pci_hpsa {         class { '::nagios::check::hpsa': } }


### PR DESCRIPTION
The check_swap plugin was changed, the version 2 returns status
"critical" if swap size equals zero. Details:
https://www.monitoring-plugins.org/repositories/monitoring-plugins/commit/?id=441913d

This commit allows to add the swap check (as part of default checks)
only if the swap present on the system (if it's size more than
zero).