### PR TITLE
Breaking this line in two seems to avoid a syntax error for me

### DIFF
--- a/manifests/check/postgres.pp
+++ b/manifests/check/postgres.pp
@@ -149,7 +149,7 @@ class nagios::check::postgres (
   }
 
   # Custom queries
-  nagios::check::postgres::custom_query { keys($custom_queries): }
-
+  $allkeys = keys($custom_queries)
+  nagios::check::postgres::custom_query { $allkeys: }
 }
 


### PR DESCRIPTION
Syntax error at ':'; expected '}' at /etc/puppet/tvs-modules/nagios/manifests/check/postgres.pp:152
