### PR TITLE
Fix nagios_ipaddress6 fact to not throw an error if ipv6 not enabled

### DIFF
--- a/lib/facter/nagios_ipaddress6.rb
+++ b/lib/facter/nagios_ipaddress6.rb
@@ -32,13 +32,11 @@ else
       Facter.value(:networking)['interfaces'].
         reject { |i,_| i =~ /lo.*/ }.
         values.
-        map { |x| x['bindings6'] }.
+        flat_map { |x| x['bindings6'] }.
         compact.
-        flatten.
         map { |x| x['address'] }.
         select { |x| valid_addr? x }.
-        sort_by { |x| x.length }.
-        shift
+        min_by(&:length)
     end
   end
 end

--- a/lib/facter/nagios_ipaddress6.rb
+++ b/lib/facter/nagios_ipaddress6.rb
@@ -33,6 +33,7 @@ else
         reject { |i,_| i =~ /lo.*/ }.
         values.
         map { |x| x['bindings6'] }.
+        reject { |x| x.nil? }.
         flatten.
         map { |x| x['address'] }.
         select { |x| valid_addr? x }.

--- a/lib/facter/nagios_ipaddress6.rb
+++ b/lib/facter/nagios_ipaddress6.rb
@@ -33,7 +33,7 @@ else
         reject { |i,_| i =~ /lo.*/ }.
         values.
         map { |x| x['bindings6'] }.
-        reject { |x| x.nil? }.
+        compact.
         flatten.
         map { |x| x['address'] }.
         select { |x| valid_addr? x }.


### PR DESCRIPTION
Fixes #93 
