### PR TITLE
updated slack_nagios

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,10 +457,10 @@ Sample Slack contact and commands configuration:
     host_notification_commands    => 'notify-host-by-slack',
   }
   nagios_command { 'notify-service-by-slack':
-    command_line => '$USER1$/slack_nagios > /tmp/slack.log 2>&1',
+    command_line => '$USER1$/slack_nagios -h "$HOSTNAME$" -n "$SERVICEDISPLAYNAME$" -o "$SERVICEOUTPUT$" -s "$SERVICESTATE$" -t "$NOTIFICATIONTYPE$" > /tmp/slack.log 2>&1',
   }
   nagios_command { 'notify-host-by-slack':
-    command_line => '$USER1$/slack_nagios > /tmp/slack.log 2>&1',
+    command_line => '$USER1$/slack_nagios -h "$HOSTNAME$" -O "$HOSTOUTPUT$" -S "$HOSTSTATE$" -t "$NOTIFICATIONTYPE$" > /tmp/slack.log 2>&1',
   }
 ```
 

--- a/templates/plugins/slack_nagios
+++ b/templates/plugins/slack_nagios
@@ -5,6 +5,26 @@ SLACK_CHANNEL='<%= @plugin_slack_channel %>'
 SLACK_BOTNAME='<%= @plugin_slack_botname %>'
 WEBHOOK_URL='<%= @plugin_slack_webhook %>' # Get it from Slack Incoming WebHooks setup instruction
 
+while getopts h:n:o:O:s:S:t: opt
+do
+  case $opt in
+    h)
+      NAGIOS_HOSTNAME=$OPTARG;;
+    n)
+      NAGIOS_SERVICEDISPLAYNAME=$OPTARG;;
+    o)
+      NAGIOS_SERVICEOUTPUT=$OPTARG;;
+    O)
+      NAGIOS_HOSTOUTPUT=$OPTARG;;
+    s)
+      NAGIOS_SERVICESTATE=$OPTARG;;
+    S)
+      NAGIOS_HOSTSTATE=$OPTARG;;
+    t)
+      NAGIOS_NOTIFICATIONTYPE=$OPTARG;;
+  esac
+done
+
 # Message parameters
 if [ -z "$NAGIOS_SERVICESTATE" ]
 then


### PR DESCRIPTION
Nagios 4 has enable_environment_macros=0 which breaks the slack_nagios script, fixed by sending macros via arguments to the slack_nagios check.