### PR TITLE
correct elasticsearch typo in mode.pp

### DIFF
--- a/manifests/check/elasticsearch/mode.pp
+++ b/manifests/check/elasticsearch/mode.pp
@@ -42,7 +42,7 @@ define nagios::check::elasticsearch::mode (
   nagios::service { "check_elasticsearch_${mode}_${check_title}":
     ensure                   => $ensure_mode,
     check_command            => "check_nrpe_elasticsearch_${mode}",
-    service_description      => "elastichsearch_${mode}",
+    service_description      => "elasticsearch_${mode}",
     servicegroups            => $servicegroups,
     check_period             => $check_period,
     contact_groups           => $contact_groups,


### PR DESCRIPTION
fix elastichsearch typo in service_description, it is labeled correctly as elasticsearch everywhere else but it shows up in the interface as for example: "elastichsearch_cluster_status"