### PR TITLE
making mailx installation optionnal

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -36,6 +36,8 @@ class nagios::server (
   $cgi_authorized_for_all_host_commands         = 'nagiosadmin',
   $cgi_default_statusmap_layout                 = '5',
   $cgi_result_limit                             = '100',
+  # mail server installation is optionnal
+  $mailx_install                = true,
   # nagios.cfg
   $cfg_file = [
     # Where puppet managed types are
@@ -216,7 +218,9 @@ class nagios::server (
 
   # Other packages
   # For the default email notifications to work
-  ensure_packages(['mailx'])
+  if $mailx_install {
+    ensure_packages(['mailx'])
+  }
 
   service { 'nagios':
     ensure    => 'running',


### PR DESCRIPTION
User may want or need to setup their mail server from outside the puppet module
This PR add this possibility 