### PR TITLE
Make paths configurable for pnp4nagios

### DIFF
--- a/manifests/pnp4nagios.pp
+++ b/manifests/pnp4nagios.pp
@@ -5,13 +5,16 @@ class nagios::pnp4nagios (
   $nagios_command_line       = '/usr/libexec/pnp4nagios/process_perfdata.pl --bulk',
   $nagios_service_name       = 'pnp4nagios-service',
   $nagios_service_action_url = '/pnp4nagios/index.php/graph?host=$HOSTNAME$&srv=$SERVICEDESC$',
+  $nagios_html_base_path     = '/usr/share/nagios/html',
   $perflog                   = '/var/log/pnp4nagios/service-perfdata',
   # The apache config snippet
   $apache_httpd              = true,
   $apache_httpd_conf_content = undef,
   $apache_httpd_conf_source  = undef,
   $apache_httpd_conf_file    = '/etc/httpd/conf.d/pnp4nagios.conf',
+  $apache_httpd_alias_path   = '/pnp4nagios',
   # Other
+  $html_base_path            = '/usr/share/nagios/html/pnp4nagios',
   $ssi                       = false
 ) {
 
@@ -61,9 +64,9 @@ class nagios::pnp4nagios (
   # https://docs.pnp4nagios.org/pnp-0.6/webfe
   # Content from /usr/share/doc/pnp4nagios-0.6.25/contrib/ssi/status-header.ssi
   if $ssi {
-    file { '/usr/share/nagios/html/ssi/common-header.ssi':
+    file { "${nagios_html_base_path}/ssi/common-header.ssi":
       ensure  => 'present',
-      source  => "puppet:///modules/${module_name}/pnp4nagios/common-header.ssi",
+      content => template("${module_name}/pnp4nagios/common-header.ssi.erb"),
       require => Package['nagios'],
     }
   }

--- a/templates/apache_httpd/httpd-pnp4nagios.conf.erb
+++ b/templates/apache_httpd/httpd-pnp4nagios.conf.erb
@@ -1,8 +1,8 @@
 # SAMPLE CONFIG SNIPPETS FOR APACHE WEB SERVER
 
-Alias /pnp4nagios "/usr/share/nagios/html/pnp4nagios"
+Alias <%= @apache_httpd_alias_path %> "<%= @html_base_path %>"
 
-<Directory "/usr/share/nagios/html/pnp4nagios">
+<Directory "<%= @html_base_path %>">
     AllowOverride None
 <% if !@apache_allowed_from.empty? -%>
     Order Deny,Allow

--- a/templates/pnp4nagios/common-header.ssi.erb
+++ b/templates/pnp4nagios/common-header.ssi.erb
@@ -1,0 +1,9 @@
+<%# vim: set ts=8 sw=2 tw=0 et ft=eruby.html :%>
+<script src="<%= @apache_httpd_alias_path %>/media/js/jquery-min.js" type="text/javascript"></script>
+<script src="<%= @apache_httpd_alias_path %>/media/js/jquery.cluetip.js" type="text/javascript"></script>
+<script type="text/javascript">
+jQuery.noConflict();
+jQuery(document).ready(function() {
+  jQuery('a.tips').cluetip({ajaxCache: false, dropShadow: false,showTitle: false });
+});
+</script>


### PR DESCRIPTION
This PR makes the HTML path `/usr/share/nagios/html` adjustable, as it might vary according to the operating system/packager/etc. The default is still the old one, so no changes for users.