### PR TITLE
Allow dis-/enabling notifications systemwide

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -72,6 +72,7 @@ class nagios::server (
   $notification_timeout  = '30',
   $ocsp_timeout          = '5',
   $perfdata_timeout      = '5',
+  $enable_notifications  = '1',
   # private/resource.cfg for $USERx$ macros (from 1 to 32)
   $user = {
     '1' => $::nagios::params::plugin_dir,

--- a/templates/nagios-4.cfg.erb
+++ b/templates/nagios-4.cfg.erb
@@ -791,7 +791,7 @@ accept_passive_host_checks=1
 # service notifications when it is initially (re)started.
 # Values: 1 = enable notifications, 0 = disable notifications
 
-enable_notifications=1
+enable_notifications=<%= @enable_notifications %>
 
 
 

--- a/templates/nagios.cfg.erb
+++ b/templates/nagios.cfg.erb
@@ -810,7 +810,7 @@ accept_passive_host_checks=1
 # service notifications when it is initially (re)started.
 # Values: 1 = enable notifications, 0 = disable notifications
 
-enable_notifications=1
+enable_notifications=<%= @enable_notifications %>
 
 
 


### PR DESCRIPTION
Convenient function for just checking that a configuration is imported
and working correctly without shouting murder as soon as any firewall
issues and similar things are noticed upon deployment.