### PR TITLE
SELinux updates for RH8

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -206,6 +206,11 @@ class nagios::client (
     selinux::audit2allow { 'nrpe':
       source => "puppet:///modules/${module_name}/messages.nrpe",
     }
+    selboolean { 'nagios_run_sudo':
+      name       => 'nagios_run_sudo',
+      persistent => true,
+      value      => on,
+    }
   }
 
   # Custom (nrpe) services/nrpe files/plugins support


### PR DESCRIPTION
SELinux updates for RH8
avc:  denied  { map } for  pid=000000 comm="sudo" path="/usr/bin/sudo" dev="sda00" ino=0000000 scontext=system_u:system_r:nrpe_t:s0 tcontext=system_u:object_r:sudo_exec_t:s0 tclass=file permissive=0