### PR TITLE
haproxy_stats change default option to not have critical on maintenan…

### DIFF
--- a/manifests/check/haproxy_stats.pp
+++ b/manifests/check/haproxy_stats.pp
@@ -1,6 +1,6 @@
 class nagios::check::haproxy_stats (
   $ensure                   = undef,
-  $args                     = '-s /var/lib/haproxy/stats -P statistics',
+  $args                     = '-s /var/lib/haproxy/stats -P statistics -m',
   $package                  = [ 'perl' ],
   $vendor_package           = undef,
   $check_title              = $::nagios::client::host_name,


### PR DESCRIPTION
haproxy_stats change default option to not have critical on maintenance (changed my mind after the last night)
