### PR TITLE
Fluentbit Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,31 @@ nagios::check::elasticsearch::args_jvm_usage: '-N 10.0.0.1 -C 90 -W 80'
 nagios::check::elasticsearch::args_nodes: '-E 5' # Expected nodes in cluester
 ```
 
+## Fluent Bit
+
+The Fluent Bit monitoring uses the `/api/v1/health` endpoint to determine the health status of Fluent Bit.
+
+The health check is performed by a custom script named `check_fluentbit_health`,
+which is located by default at `/usr/lib64/nagios/plugins/`.
+This script checks the health of the Fluent Bit service by accessing the API endpoint `/api/v1/health`,
+which provides health status directly from the Fluent Bit service.
+
+### Configuring Fluent Bit Health Service
+
+To utilize the health check functionality, Fluent Bit must be configured to enable its built-in HTTP server,
+which exposes the `/api/v1/health` endpoint.
+
+For more information please check [Health Check for Fluent Bit](https://docs.fluentbit.io/manual/administration/monitoring#health-check-for-fluent-bit)
+
+### Script Configuration
+
+By default, localhost and port 2020 are used for the check but you can customize it from hiera:
+
+```yaml
+# Fluent Bit health check parameters
+nagios::check::fluentbit::args: '-H your-fluentbit-host -p your-port-number'
+```
+
 ## Kafka
 
 Kafka monitoring checks producing to and consuming from specific Kafka topic,

--- a/files/scripts/check_fluentbit_health
+++ b/files/scripts/check_fluentbit_health
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Default Fluent Bit host and port
+FLUENTBIT_HOST="localhost"
+FLUENTBIT_PORT="2020"
+
+while getopts "H:p:" opt; do
+  case $opt in
+    H)
+      FLUENTBIT_HOST=$OPTARG
+      ;;
+    p)
+      FLUENTBIT_PORT=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Fluent Bit health check URL
+FLUENTBIT_HEALTH_URL="http://${FLUENTBIT_HOST}:${FLUENTBIT_PORT}/api/v1/health"
+
+# Use curl to get the HTTP status code
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" $FLUENTBIT_HEALTH_URL)
+
+# Check if the status code is 200
+if [ "$HTTP_STATUS" -eq 200 ]; then
+    echo "OK: Fluent Bit is healthy."
+    exit 0
+else
+    echo "CRITICAL: Fluent Bit is not healthy. HTTP Status: $HTTP_STATUS"
+    exit 2
+fi

--- a/lib/facter/nagios_fluentbit.rb
+++ b/lib/facter/nagios_fluentbit.rb
@@ -1,0 +1,6 @@
+# Create custom nagios_fluentbit if fluentbit binary is found
+
+if FileTest.exists?('/usr/bin/fluent-bit')
+  Facter.add('nagios_fluentbit') { setcode { true } }
+end
+

--- a/manifests/check/fluentbit.pp
+++ b/manifests/check/fluentbit.pp
@@ -1,0 +1,53 @@
+class nagios::check::fluentbit (
+  Enum['present','absent'] $ensure                   = 'present',
+  Optional[String]         $args                     = '',
+  Optional[String]         $check_title              = $::nagios::client::host_name,
+  Optional[String]         $servicegroups            = undef,
+  Optional[String]         $check_period             = $::nagios::client::service_check_period,
+  Optional[String]         $contact_groups           = $::nagios::client::service_contact_groups,
+  Optional[String]         $first_notification_delay = $::nagios::client::service_first_notification_delay,
+  Optional[String]         $max_check_attempts       = $::nagios::client::service_max_check_attempts,
+  Optional[String]         $notification_period      = $::nagios::client::service_notification_period,
+  Optional[String]         $use                      = $::nagios::client::service_use,
+) inherits ::nagios::client {
+
+  if $ensure != 'absent' {
+    Package <| tag == 'nagios-plugins-fluentbit' |>
+  }
+
+  # Include defaults if no overrides in $args
+  if $args !~ /-H/ { $arg_h = '-H localhost ' } else { $arg_h = '' }
+  if $args !~ /-p/ { $arg_p = '-p 2020 '       } else { $arg_p = '' }
+  $fullargs = strip("${arg_h}${arg_p}${args}")
+
+  # Let's check if the fluentbit check script is present and if not copy it
+  file { '/usr/lib64/nagios/plugins/check_fluentbit_health':
+    ensure => $ensure,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+    source => "puppet:///modules/${module_name}/scripts/check_fluentbit_health",
+  }
+
+  nagios::client::nrpe_file { 'check_fluentbit_health':
+    ensure  => $ensure,
+    args    => $fullargs,
+    require => File['/usr/lib64/nagios/plugins/check_fluentbit_health'],
+    plugin  => 'check_fluentbit_health',
+  }
+
+  nagios::service { "check_fluentbit_health_${check_title}":
+    ensure                   => $ensure,
+    check_command            => 'check_nrpe_fluentbit_health',
+    service_description      => 'fluentbit_health',
+    servicegroups            => $servicegroups,
+    check_period             => $check_period,
+    contact_groups           => $contact_groups,
+    first_notification_delay => $first_notification_delay,
+    notification_period      => $notification_period,
+    max_check_attempts       => $max_check_attempts,
+    use                      => $use,
+  }
+
+}  
+

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -200,6 +200,7 @@ class nagios::client (
     }
     if getvar('::virtual') == 'physical' {  class { '::nagios::check::cpu_temp': } }
     if getvar('::nagios_elasticsearch') {  class { '::nagios::check::elasticsearch': } }
+    if getvar('::nagios_fluentbit') {  class { '::nagios::check::fluentbit': } }
     if getvar('::nagios_kafka') {
       class { '::nagios::check::kafka': }
       class { '::nagios::check::kafka_isr': }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1025,6 +1025,9 @@ class nagios::server (
   nagios_command { 'check_nrpe_elasticsearch_unassigned_shards':
     command_line => "${nrpe} -c check_elasticsearch_unassigned_shards",
   }
+  nagios_command { 'check_nrpe_fluentbit_health':
+    command_line => "${nrpe} -c check_fluentbit_health",
+  }
   nagios_command { 'check_nrpe_ssd':
     command_line => "${nrpe} -c check_ssd",
   }


### PR DESCRIPTION
The Fluent Bit check uses the `/api/v1/health` endpoint to determine the health status of Fluent Bit.
The health check is performed by a custom script named `check_fluentbit_health`,
which is located by default at `/usr/lib64/nagios/plugins/`
This script checks the health of the Fluent Bit service by accessing the API endpoint `/api/v1/health`,
which provides health status directly from the Fluent Bit service.

By default, localhost and port 2020 are used for the check but you can customize it from hiera:
nagios::check::fluentbit::args: '-H your-fluentbit-host -p your-port-number'