### PR TITLE
stop using validate_hash(), refresh metadata.json

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -68,7 +68,7 @@ class nagios::server (
   $date_format = 'iso8601',
   $admin_email = 'root@localhost',
   $admin_pager = 'pagenagios@localhost',
-  $cfg_append  = undef,
+  Optional[Hash] $cfg_append = undef,
   $service_check_timeout = '60',
   $host_check_timeout    = '30',
   $event_handler_timeout = '30',
@@ -302,9 +302,6 @@ class nagios::server (
   }
 
   # Configuration files
-  if ($cfg_append != undef) {
-    validate_hash($cfg_append)
-  }
   file { '/etc/nagios/cgi.cfg':
     owner   => 'root',
     group   => 'root',

--- a/metadata.json
+++ b/metadata.json
@@ -11,17 +11,17 @@
   "operatingsystem_support": [
     {
     "operatingsystem": "RedHat",
-    "operatingsystemrelease": [ "5", "6", "7" ]
+    "operatingsystemrelease": [ "5", "6", "7", "8", "9" ]
     },
     {
     "operatingsystem": "CentOS",
-    "operatingsystemrelease": [ "5", "6", "7" ]
+    "operatingsystemrelease": [ "5", "6", "7", "8" ]
     }
   ],
   "requirements": [
     {
     "name": "puppet",
-    "version_requirement": ">=4.0.20 <7.0.0"
+    "version_requirement": ">=4.0.20 <8.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
`validate_hash()` was removed from stdlib in version 9.0.0.  an alternative is to use puppet's built-in class parameter validation.

also add some entries to metadata.json because I'm successfully using the module with newer versions of puppet & RHEL/CentOS.