### PR TITLE
Add Disk Projection and CPU Persistent Monitoring Checks to puppet-nagios

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,38 @@ On the other hand, if you want monitor multiple sentinels on a single host you m
 
 Note: In these kinds of scenarios the plugins will run on the Nagios Server. The nrpe agent won't be used to perform these checks.
 
+## Disk Usage Projection
+
+The Disk Usage Projection check monitors disk usage trends and predicts when a disk will be full based on current usage patterns. This proactive approach helps identify potential capacity issues before they become critical.
+
+By default, it excludes temporary filesystems like `tmpfs` and allows configuring thresholds via Hiera:
+
+```yaml
+# Disk Usage Projection check parameters
+nagios::check::disk_projection::ensure: 'present'
+nagios::check::disk_projection::time_threshold: 12  # Trigger alert if projected full within 12 hours
+nagios::check::disk_projection::exclude_fs: 'tmpfs|devtmpfs|shm|overlay'
+```
+
+You can modify parameters such as time thresholds and excluded filesystems to fit your environment.
+
+## Persistent CPU Usage Monitoring
+
+The Persistent CPU Usage Monitoring check tracks sustained CPU usage over a defined period, triggering alerts only when usage exceeds thresholds for a continuous duration. This prevents transient spikes from causing unnecessary alerts.
+
+By default, it monitors all processes and can be configured via Hiera:
+
+```yaml
+# Persistent CPU Usage check parameters
+nagios::check::cpu_persistent::ensure: 'present'
+nagios::check::cpu_persistent::warn: '75'           # Warning threshold for CPU usage percentage
+nagios::check::cpu_persistent::crit: '90'           # Critical threshold for CPU usage percentage
+nagios::check::cpu_persistent::warn_duration: '5'   # Warning duration in minutes
+nagios::check::cpu_persistent::crit_duration: '10'  # Critical duration in minutes
+```
+
+Adjust thresholds and durations based on your requirements to ensure the check fits your operational needs.
+
 ## RHEL Identity Manager
 
 RHEL IDM manages few services. In this module we only monitor the following:

--- a/files/scripts/check_cpu_persistent
+++ b/files/scripts/check_cpu_persistent
@@ -1,0 +1,128 @@
+#!/usr/libexec/platform-python
+
+"""
+CPU Usage Persistent Monitoring Script
+
+This script monitors the CPU usage over time and triggers alerts if the usage exceeds
+specific warning or critical thresholds for a sustained duration. It is designed to
+avoid transient spikes from generating unnecessary alerts.
+
+Features:
+- Monitors total CPU usage using the `vmstat` command.
+- Supports configurable thresholds and durations for warning and critical alerts.
+- Tracks state between executions to ensure persistence.
+
+Options:
+    -w, --warning: Warning threshold for CPU usage (percentage). Default: 70.
+    -c, --critical: Critical threshold for CPU usage (percentage). Default: 85.
+    --warn_duration: Duration (in minutes) for CPU usage to exceed warning threshold before triggering an alert. Default: 3.
+    --crit_duration: Duration (in minutes) for CPU usage to exceed critical threshold before triggering an alert. Default: 5.
+    -s, --sample: Sampling interval in seconds. Default: 5.
+    --state_file: Path to the state file used to store persistent data. Default: /var/tmp/cpu_check_state.json.
+
+Exit Codes:
+    0: OK - CPU usage is within normal thresholds.
+    1: WARNING - CPU usage has exceeded the warning threshold for the defined duration.
+    2: CRITICAL - CPU usage has exceeded the critical threshold for the defined duration.
+    3: UNKNOWN/ERROR - An error occurred during execution.
+
+Usage:
+    Run the script manually or configure it as a Nagios NRPE check:
+    ./cpu_usage_monitor.py -w 75 -c 90 --warn_duration 5 --crit_duration 10 -s 5 --state_file /custom/path/state.json
+"""
+
+import os
+import json
+import time
+from optparse import OptionParser
+import sys
+
+# Constants for state file location
+STATE_FILE = "/var/tmp/cpu_check_state.json"
+
+# Parse arguments
+parser = OptionParser()
+parser.add_option("-w", "--warning", action="store", type="int", dest="warn", default=70, help="Warning threshold for CPU usage (percentage). Default: 70")
+parser.add_option("-c", "--critical", action="store", type="int", dest="crit", default=85, help="Critical threshold for CPU usage (percentage). Default: 85")
+parser.add_option("--warn_duration", action="store", type="int", dest="warn_duration", default=3, help="Duration in minutes for which CPU usage must exceed warning threshold. Default: 3")
+parser.add_option("--crit_duration", action="store", type="int", dest="crit_duration", default=5, help="Duration in minutes for which CPU usage must exceed critical threshold. Default: 5")
+parser.add_option("-s", "--sample", action="store", type="int", dest="sample", default=5, help="Sampling interval in seconds. Default: 5")
+parser.add_option("--state_file", action="store", type="str", dest="state_file", default="/var/tmp/cpu_check_state.json", help="Path to the state file. Default: /var/tmp/cpu_check_state.json")
+(options, args) = parser.parse_args()
+
+# Load or initialize state
+if os.path.exists(STATE_FILE):
+    with open(STATE_FILE, "r") as f:
+        state = json.load(f)
+else:
+    state = {"critical_start": None, "warning_start": None}
+
+# Function to get CPU idle time using vmstat
+def get_cpu_usage(sample):
+    vmstat_output = os.popen(f"/usr/bin/vmstat {sample} 2").read().strip().split('\n')
+    
+    # Ensure output has enough lines
+    if len(vmstat_output) < 3:
+        print("Error: Unexpected vmstat output format.")
+        sys.exit(3)
+    
+    # Extract headers and determine the position of 'id'
+    headers = vmstat_output[1].strip().split()
+    if "id" not in headers:
+        print("Error: Could not locate 'id' column in vmstat headers.")
+        sys.exit(3)
+
+    id_index = headers.index("id")  # Find the index of the 'id' column
+    
+    # Parse the last data row
+    last_line = vmstat_output[-1].strip().split()
+    try:
+        idle_cpu = int(last_line[id_index])  # Use the dynamic index for 'id'
+    except (ValueError, IndexError):
+        print("Error: Could not parse idle CPU from vmstat output.")
+        sys.exit(3)
+    
+    busy_cpu = 100 - idle_cpu
+    return busy_cpu
+
+# Check CPU usage
+busy_cpu = get_cpu_usage(options.sample)
+current_time = time.time()
+
+# Update state with timestamps for warning and critical conditions
+if busy_cpu >= options.crit:
+    if state["critical_start"] is None:
+        state["critical_start"] = current_time
+    # Keep tracking warning start time if it was already set
+    if state["warning_start"] is None:
+        state["warning_start"] = current_time
+elif busy_cpu >= options.warn:
+    if state["warning_start"] is None:
+        state["warning_start"] = current_time
+    state["critical_start"] = None  # Reset critical start if below critical
+else:
+    state["warning_start"] = None
+    state["critical_start"] = None
+
+# Calculate elapsed time for warning and critical conditions
+warn_elapsed = current_time - state["warning_start"] if state["warning_start"] else 0
+crit_elapsed = current_time - state["critical_start"] if state["critical_start"] else 0
+
+# Evaluate thresholds
+if crit_elapsed >= options.crit_duration * 60:
+    status = f"CPU CRITICAL: CPU usage has been over {options.crit}% for {options.crit_duration} minutes"
+    exit_code = 2
+elif warn_elapsed >= options.warn_duration * 60:
+    status = f"CPU WARNING: CPU usage has been over {options.warn}% for {options.warn_duration} minutes"
+    exit_code = 1
+else:
+    status = f"CPU OK: CPU usage is {busy_cpu}%"
+    exit_code = 0
+
+# Save state to file
+with open(STATE_FILE, "w") as f:
+    json.dump(state, f)
+
+# Output status and exit
+print(f"{status} | cpu={busy_cpu}%;{options.warn};{options.crit};0;100")
+sys.exit(exit_code)

--- a/files/scripts/check_disk_usage_projection
+++ b/files/scripts/check_disk_usage_projection
@@ -1,0 +1,253 @@
+#!/bin/bash
+
+# Disk Usage Projection Monitoring Script
+#
+# This script monitors disk usage trends and projects the estimated time until a
+# disk becomes full based on historical usage patterns. It calculates the rate
+# of change for each monitored disk and triggers alerts if a disk is projected
+# to fill within a specified time threshold.
+#
+# Features:
+# - Tracks disk usage over time and stores historical data.
+# - Projects the estimated time until full for each monitored disk.
+# - Configurable time thresholds for triggering alerts.
+# - Excludes specified filesystem types from monitoring.
+# - Filters out minor usage fluctuations below a specified threshold.
+#
+# Default Usage Data Directory:
+# - The script stores usage data in `/var/tmp/disk_usage_data` by default.
+# - The directory can be changed using the `--data-dir` option.
+#
+# Options:
+#   -t, --time HOURS               Set the time threshold in hours for triggering alerts (default: 12).
+#   -x, --exclude FSTYPES          Exclude the specified filesystem types (default: tmpfs|devtmpfs|shm|efivarfs|binfmt_misc|rpc_pipefs|cgroup|tracefs|overlay|nsfs).
+#   --data-dir DIRECTORY           Set the directory for storing usage data (default: /var/tmp/disk_usage_data).
+#   --fluctuation-threshold MB     Ignore fluctuations smaller than the specified threshold (default: 1 MB).
+#   -h, --help                     Display this help message and exit.
+#
+# Exit Codes:
+#   0: OK - All monitored disks have sufficient space based on the time threshold.
+#   2: CRITICAL - At least one monitored disk is projected to fill within the specified time threshold.
+#   3: UNKNOWN - An error occurred or insufficient data is available.
+#
+# Example Usage:
+#   ./disk_usage_projection.sh --time 24 --exclude "tmpfs|devtmpfs" --data-dir /custom/path
+#
+# Notes:
+# - Ensure the `df` command is available on the system.
+# - Historical usage data is retained for up to 7 days and purged automatically.
+
+# Default directory for storing usage data
+usage_data_dir="/var/tmp/disk_usage_data"
+
+# Function to display help
+show_help() {
+    echo "Usage: $0 [-t|--time HOURS] [-x|--exclude FSTYPES] [--data-dir DIRECTORY] [-h|--help]"
+    echo
+    echo "Options:"
+    echo "  -t, --time HOURS       Set the threshold time in hours (default: 12)"
+    echo "  -x, --exclude FSTYPES  Exclude the specified filesystem types (default: tmpfs|devtmpfs|shm|efivarfs|binfmt_misc|rpc_pipefs|cgroup|tracefs|overlay|nsfs)"
+    echo "  --data-dir DIRECTORY   Set the directory to store usage data (default: /var/tmp/disk_usage_data)"
+    echo "  --fluctuation-threshold MB    Ignore fluctuations smaller than this threshold (default: 1 MB)"
+    echo "  -h, --help             Display this help message"
+}
+
+# Function to get current disk usage
+get_disk_usage() {
+    df -k "$1" | awk 'NR==2 {print $3,$2}'  # Used and total in KB
+}
+
+# Function to load usage data
+load_usage_data() {
+    local usage_data_file="$1"
+    if [ -f "$usage_data_file" ]; then
+        cat "$usage_data_file"
+    else
+        echo ""
+    fi
+}
+
+# Function to save usage data
+save_usage_data() {
+    local usage_data_file="$1"
+    echo "$2" > "$usage_data_file"
+}
+
+# Function to calculate projection
+calculate_projection() {
+    local data="$1"
+    local current_time="$2"
+    local fluctuation_threshold_kb=$((fluctuation_threshold_mb * 1024))  # Convert MB to KB
+
+    # Count data points
+    local data_points
+    data_points=$(echo "$data" | wc -l)
+
+    # Ensure at least two data points exist
+    if [ "$data_points" -lt 2 ]; then
+        echo "OK: Insufficient data points: $data_points (minimum 2 needed)"
+        return
+    fi
+
+    local first_entry
+    local last_entry
+
+    first_entry=$(echo "$data" | head -n 1)
+    last_entry=$(echo "$data" | tail -n 1)
+
+    local first_timestamp
+    local first_used
+    local last_timestamp
+    local last_used
+    local total
+
+    first_timestamp=$(echo "$first_entry" | cut -d',' -f1)
+    first_used=$(echo "$first_entry" | cut -d',' -f2)
+    last_timestamp=$(echo "$last_entry" | cut -d',' -f1)
+    last_used=$(echo "$last_entry" | cut -d',' -f2)
+    total=$(echo "$last_entry" | cut -d',' -f3)
+
+    if [ "$first_timestamp" -eq "$last_timestamp" ]; then
+        echo "OK: Insufficient time difference between data points"
+        return
+    fi
+
+    # Calculate rate of change
+    local rate_of_change
+    rate_of_change=$(( (last_used - first_used) / (last_timestamp - first_timestamp) ))
+
+    # Check if rate of change is negligible or negative
+    local usage_diff=$((last_used - first_used))
+    local time_diff=$((last_timestamp - first_timestamp))
+
+    # Ignore fluctuations below the threshold
+    if [ "${usage_diff#-}" -lt "$fluctuation_threshold_kb" ]; then
+        echo "OK: No significant growth: Usage fluctuated by $((usage_diff / 1024)) MB over $((time_diff / 60)) minutes"
+        return
+    fi
+
+    if [ "$rate_of_change" -le 0 ]; then
+        echo "OK: No growth detected or negative growth"
+        return
+    fi
+
+    # Calculate time until full
+    local time_until_full=$(( (total - last_used) / rate_of_change ))
+    echo "$((last_timestamp + time_until_full))"
+}
+
+# Default values
+threshold_hours=12
+exclude_fs="tmpfs|devtmpfs|shm|efivarfs|binfmt_misc|rpc_pipefs|cgroup|tracefs|overlay|nsfs"
+fluctuation_threshold_mb=1  # Default fluctuation threshold: 1 MB
+
+# Parse command line arguments
+PARSED_ARGS=$(getopt -o t:x:h --long time:,exclude:,data-dir:,help -- "$@")
+if [[ $? -ne 0 ]]; then
+    show_help
+    exit 3
+fi
+
+eval set -- "$PARSED_ARGS"
+
+while true; do
+    case "$1" in
+        -t|--time)
+            threshold_hours="$2"
+            shift 2
+            ;;
+        -x|--exclude)
+            exclude_fs="$2"
+            shift 2
+            ;;
+        --data-dir)
+            usage_data_dir="$2"
+            shift 2
+            ;;
+        --fluctuation-threshold)
+            fluctuation_threshold_mb="$2"
+            shift 2
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            show_help
+            exit 3
+            ;;
+    esac
+done
+
+# Ensure the usage data directory exists
+mkdir -p "$usage_data_dir"
+
+# Main function
+main() {
+    current_time=$(date +%s)
+    threshold_seconds=$((threshold_hours * 3600))
+    all_disks_ok=true
+    summary=""
+    performance_data=""
+
+    # Build the df command with -x options
+    df_command="df -k -P"
+    for fs in $(echo "$exclude_fs" | tr '|' ' '); do
+        df_command="$df_command -x $fs"
+    done
+
+    # Iterate over all mounted disks
+    while IFS= read -r mount_point; do
+        usage_data_file="$usage_data_dir/disk_$(echo "$mount_point" | sed 's|/|_|g' | sed 's|^_|root_|').txt"
+        disk_usage=$(get_disk_usage "$mount_point")
+        used_bytes=$(echo "$disk_usage" | awk '{print $1}')
+        total_bytes=$(echo "$disk_usage" | awk '{print $2}')
+
+        # Load existing usage data
+        data=$(load_usage_data "$usage_data_file")
+
+        # Append current usage data
+        data=$(echo -e "$data\n$current_time,$used_bytes,$total_bytes")
+
+        # Keep only the last 7 days of data points
+        data=$(echo "$data" | awk -v ct="$current_time" '($1 + 604800) > ct')
+
+        # Save updated usage data
+        save_usage_data "$usage_data_file" "$data"
+
+        # Calculate projection
+        projection_time=$(calculate_projection "$data" "$current_time")
+
+        if [[ "$projection_time" == OK:* ]]; then
+            summary+="$projection_time for disk $mount_point; "
+            performance_data+="$mount_point=NaN; "
+        else
+            time_until_full=$((projection_time - current_time))
+            rounded_hours=$(echo "$time_until_full / 3600" | bc -l | awk '{printf "%.2f", $0}')
+            if [ "$time_until_full" -lt "$threshold_seconds" ]; then
+                summary+="CRITICAL: Disk $mount_point will be full in less than $threshold_hours hours ($rounded_hours hours); "
+                all_disks_ok=false
+            else
+                summary+="OK: Disk $mount_point has more than $threshold_hours hours of space left ($rounded_hours hours); "
+            fi
+            performance_data+="$mount_point=$rounded_hours hours; "
+        fi
+    done < <($df_command | awk 'NR>1 {print $6}')
+
+    if [ "$all_disks_ok" = false ]; then
+        echo -n "CRITICAL: $summary | $performance_data"
+        exit 2
+    elif [[ "$summary" == *"UNKNOWN"* ]]; then
+        echo -n "UNKNOWN: $summary | $performance_data"
+        exit 3
+    else
+        echo -n "OK: $summary | $performance_data"
+        exit 0
+    fi
+}
+
+main

--- a/manifests/check/cpu_persistent.pp
+++ b/manifests/check/cpu_persistent.pp
@@ -72,7 +72,7 @@ class nagios::check::cpu_persistent (
   nagios::service { "check_cpu_persistent_${check_title}":
     ensure                   => $ensure,
     check_command            => 'check_nrpe_cpu_persistent',
-    service_description      => 'Persistent CPU Usage Check',
+    service_description      => 'cpu_persistent_usage',
     servicegroups            => $servicegroups,
     check_period             => $check_period,
     contact_groups           => $contact_groups,

--- a/manifests/check/cpu_persistent.pp
+++ b/manifests/check/cpu_persistent.pp
@@ -1,0 +1,84 @@
+class nagios::check::cpu_persistent (
+  Enum['present', 'absent'] $ensure                   = 'present',
+  Optional[String]          $args                     = '',
+  Optional[String]          $check_title              = $::nagios::client::host_name,
+  Optional[String]          $servicegroups            = undef,
+  Optional[String]          $check_period             = $::nagios::client::service_check_period,
+  Optional[String]          $contact_groups           = $::nagios::client::service_contact_groups,
+  Optional[String]          $first_notification_delay = $::nagios::client::service_first_notification_delay,
+  Optional[String]          $max_check_attempts       = $::nagios::client::service_max_check_attempts,
+  Optional[String]          $notification_period      = $::nagios::client::service_notification_period,
+  Optional[String]          $use                      = $::nagios::client::service_use,
+  Optional[String]          $warn                     = '70',
+  Optional[String]          $crit                     = '85',
+  Optional[String]          $warn_duration            = '3',
+  Optional[String]          $crit_duration            = '5',
+) inherits ::nagios::client {
+
+  # Define regex patterns for case-insensitive matching
+  $warn_regex = /-w|-W/
+  $crit_regex = /-c|-C/
+  $warn_dur_regex = /--warn_duration|--WARN_DURATION/
+  $crit_dur_regex = /--crit_duration|--CRIT_DURATION/
+
+  # Check each parameter and append defaults if missing
+  if $args !~ $warn_regex and $warn != undef {
+    $arg_w = "-w ${warn} "
+  } else {
+    $arg_w = ''
+  }
+
+  if $args !~ $crit_regex and $crit != undef {
+    $arg_c = "-c ${crit} "
+  } else {
+    $arg_c = ''
+  }
+
+  if $args !~ $warn_dur_regex and $warn_duration != undef {
+    $arg_warn_dur = "--warn_duration ${warn_duration} "
+  } else {
+    $arg_warn_dur = ''
+  }
+
+  if $args !~ $crit_dur_regex and $crit_duration != undef {
+    $arg_crit_dur = "--crit_duration ${crit_duration} "
+  } else {
+    $arg_crit_dur = ''
+  }
+
+  # Combine all arguments
+  $globalargs = strip("${arg_w}${arg_c}${arg_warn_dur}${arg_crit_dur}${args}")
+
+
+
+  # Deploy the check script
+  file { '/usr/lib64/nagios/plugins/check_cpu_persistent':
+    ensure => $ensure,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+    source => "puppet:///modules/${module_name}/scripts/check_cpu_persistent",
+  }
+
+  # Configure NRPE file for the new plugin
+  nagios::client::nrpe_file { 'check_cpu_persistent':
+    ensure  => $ensure,
+    args    => $args,
+    require => File['/usr/lib64/nagios/plugins/check_cpu_persistent'],
+    plugin  => 'check_cpu_persistent',
+  }
+
+  # Define the Nagios service
+  nagios::service { "check_cpu_persistent_${check_title}":
+    ensure                   => $ensure,
+    check_command            => 'check_nrpe_cpu_persistent',
+    service_description      => 'Persistent CPU Usage Check',
+    servicegroups            => $servicegroups,
+    check_period             => $check_period,
+    contact_groups           => $contact_groups,
+    first_notification_delay => $first_notification_delay,
+    notification_period      => $notification_period,
+    max_check_attempts       => $max_check_attempts,
+    use                      => $use,
+  }
+}

--- a/manifests/check/disk_projection.pp
+++ b/manifests/check/disk_projection.pp
@@ -1,0 +1,47 @@
+class nagios::check::disk_projection (
+  $ensure                   = 'present',
+  $time_threshold           = 12,
+  $exclude_fs               = 'tmpfs|devtmpfs|shm|efivarfs|binfmt_misc|rpc_pipefs|cgroup|tracefs|overlay|nsfs',
+  $check_title              = $::nagios::client::host_name,
+  $servicegroups            = undef,
+  $check_period             = $::nagios::client::service_check_period,
+  $contact_groups           = $::nagios::client::service_contact_groups,
+  $first_notification_delay = $::nagios::client::service_first_notification_delay,
+  $max_check_attempts       = $::nagios::client::service_max_check_attempts,
+  $notification_period      = $::nagios::client::service_notification_period,
+  $use                      = $::nagios::client::service_use,
+) inherits ::nagios::client {
+
+  if $ensure != 'absent' {
+    file { '/usr/lib64/nagios/plugins/check_disk_usage_projection':
+      ensure => $ensure,
+      source => "puppet:///modules/${module_name}/scripts/check_disk_usage_projection",
+      mode   => '0755',
+      owner  => 'root',
+      group  => 'root',
+    }
+  }
+
+  $args = "--time ${time_threshold} --exclude \"${exclude_fs}\""
+
+  nagios::client::nrpe_file { 'check_disk_usage_projection':
+    ensure  => $ensure,
+    args    => $args,
+    require => File['/usr/lib64/nagios/plugins/check_disk_usage_projection'],
+  }
+
+  nagios::service { "check_disk_usage_projection_${check_title}":
+    ensure                   => $ensure,
+    check_command            => 'check_nrpe_disk_projection',
+    service_description      => 'disk_usage_projection',
+    servicegroups            => $servicegroups,
+    check_period             => $check_period,
+    contact_groups           => $contact_groups,
+    first_notification_delay => $first_notification_delay,
+    notification_period      => $notification_period,
+    max_check_attempts       => $max_check_attempts,
+    use                      => $use,
+  }
+
+}
+

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -201,6 +201,12 @@ class nagios::client (
     if getvar('::virtual') == 'physical' {  class { '::nagios::check::cpu_temp': } }
     if getvar('::nagios_elasticsearch') {  class { '::nagios::check::elasticsearch': } }
     if getvar('::nagios_fluentbit') {  class { '::nagios::check::fluentbit': } }
+    if lookup('nagios::check::cpu_persistent::ensure', String, 'first', 'absent') == 'present' {
+      class { '::nagios::check::cpu_persistent': }
+    }
+    if lookup('nagios::check::disk_projection::ensure', String, 'first', 'absent') == 'present' {
+      class { '::nagios::check::disk_projection': }
+    }
     if getvar('::nagios_kafka') {
       class { '::nagios::check::kafka': }
       class { '::nagios::check::kafka_isr': }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1028,6 +1028,12 @@ class nagios::server (
   nagios_command { 'check_nrpe_fluentbit_health':
     command_line => "${nrpe} -c check_fluentbit_health",
   }
+  nagios_command { 'check_nrpe_cpu_persistent':
+    command_line => "${nrpe} -c check_cpu_persistent",
+  }
+  nagios_command { 'check_nrpe_disk_projection':
+    command_line => "${nrpe} -c check_disk_usage_projection",
+  }
   nagios_command { 'check_nrpe_ssd':
     command_line => "${nrpe} -c check_ssd",
   }


### PR DESCRIPTION
1. **Disk Usage Projection Check (`disk_projection`)**:
   - Tracks disk usage trends and projects when a disk will fill based on current patterns.
   - Customizable thresholds for triggering alerts (default: 12 hours).
   - Allows exclusion of specific filesystem types (e.g., `tmpfs`).
   - Stores historical data for 7 days in `/var/tmp/disk_usage_data`.
   - Reduces noise by ignoring minor fluctuations below a configurable threshold.

2. **Persistent CPU Usage Check (`cpu_persistent`)**:
   - Monitors CPU usage at the system level, triggering alerts only after sustained high usage.
   - Configurable warning and critical thresholds, along with duration parameters.
   - Prevents false positives caused by transient spikes in CPU activity.
   - Uses `vmstat` for CPU monitoring.

Key Changes:
- Added new Puppet classes `nagios::check::disk_projection` and `nagios::check::cpu_persistent`.
- Created and deployed respective NRPE plugins for both checks.
- Included Hiera configuration examples for easy integration and customization.

Testing:
- Manually tested the scripts for both checks under simulated conditions.
- Verified proper configuration and execution via NRPE and Nagios.

Notes:
These additions provide proactive monitoring capabilities for disk and CPU usage, enhancing system reliability and reducing noise in alerts.