### PR TITLE
Updated the haproxy_stats manifest args

### DIFF
--- a/manifests/check/haproxy_stats.pp
+++ b/manifests/check/haproxy_stats.pp
@@ -1,6 +1,6 @@
 class nagios::check::haproxy_stats (
   $ensure                   = undef,
-  $args                     = '-s /var/lib/haproxy/stats -P statistics -m',
+  $args                     = '-s /var/lib/haproxy/stats -P statistics -m --no-stats-exit-code 2',
   $package                  = [ 'perl' ],
   $vendor_package           = undef,
   $check_title              = $::nagios::client::host_name,


### PR DESCRIPTION
Updated the haproxy_stats manifest args to include --no-stats-exit-code 2
This ensures that failures to retrieve HAProxy stats are treated as critical (exitcode = 2) instead of unknown (exitcode = 3).