### PR TITLE
feat(nagios): add check_nvidia_gpu plugin and README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,51 @@ By default, localhost and port 2020 are used for the check but you can customize
 nagios::check::fluentbit::args: '-H your-fluentbit-host -p your-port-number'
 ```
 
+## NVIDIA GPU
+
+Monitors GPU utilization using `nvidia-smi` via the custom `check_nvidia_gpu`
+plugin (default path: `/usr/lib64/nagios/plugins/`).
+
+By default, the check alerts on **GPU utilization** at **70% (WARNING)** and
+**90% (CRITICAL)**.
+
+### Requirements
+Requires `nvidia-smi` on the target host. The custom fact `nagios_nvidia_gpu`
+automatically enables this check when the binary is detected.
+
+### Configuration & Modes
+The check operates in two modes:
+* **`aggregate`**: Checks all GPUs and returns the worst state found (Default).
+* **`single`**: Checks only the specific GPU index provided.
+
+Configure the check via Hiera using either dedicated parameters or a raw arguments string:
+
+```yaml
+# Option 1: Dedicated parameters (Recommended)
+nagios::check::nvidia_gpu::warning: 80
+nagios::check::nvidia_gpu::critical: 95
+nagios::check::nvidia_gpu::mode: 'single'
+nagios::check::nvidia_gpu::gpu_index: 0
+
+# Option 2: Raw arguments string
+nagios::check::nvidia_gpu::args: '-w 80 -c 95 -m single -i 0'
+```
+
+### Output & Metrics
+
+The script outputs standard Nagios status strings and performance data on the
+first line. On NRPE v3+, it appends multi-line "long output" detailing context
+like VRAM usage, temperature, and hardware models.
+
+**Performance Data Tracked:** `gpuX_util`, `gpuX_memutil`, `gpuX_mem_used`, `gpuX_temp`
+
+**Example Output:**
+```text
+OK - GPU utilization OK (max=0%) | gpu0_util=0%;70;90;0;100 gpu0_memutil=0%;;;0;100 gpu0_mem_used=14042MB;;;0;15360 gpu0_temp=28;;;;
+Mode: aggregate
+gpu0(Quadro RTX 5000) util=0% memutil=0% vram=14042/15360MB temp=28C
+```
+
 ## Kafka
 
 Kafka monitoring checks producing to and consuming from specific Kafka topic,

--- a/files/scripts/check_nvidia_gpu
+++ b/files/scripts/check_nvidia_gpu
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+set -u
+
+WARN=70
+CRIT=90
+MODE="aggregate"
+GPU_INDEX=""
+NVIDIA_SMI="${NVIDIA_SMI:-/bin/nvidia-smi}"
+
+usage() {
+  printf '%s\n' \
+    'Usage:' \
+    '  check_nvidia_gpu -w <warn> -c <crit> [-m aggregate|single] [-i gpu_index]' \
+    '' \
+    'Modes:' \
+    '  aggregate   Check all GPUs and return the worst state found (default)' \
+    '  single      Check only the GPU specified with -i' \
+    '' \
+    'Examples:' \
+    '  check_nvidia_gpu -w 70 -c 90' \
+    '  check_nvidia_gpu -w 70 -c 90 -m aggregate' \
+    '  check_nvidia_gpu -w 70 -c 90 -m single -i 0'
+  exit 3
+}
+
+trim() {
+  local s="$*"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+is_int() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+join_by() {
+  local IFS="$1"
+  shift
+  printf '%s' "$*"
+}
+
+while getopts ':w:c:m:i:h' opt; do
+  case "$opt" in
+    w) WARN="$OPTARG" ;;
+    c) CRIT="$OPTARG" ;;
+    m) MODE="$OPTARG" ;;
+    i) GPU_INDEX="$OPTARG" ;;
+    h) usage ;;
+    :) printf 'UNKNOWN - option -%s requires an argument\n' "$OPTARG"; exit 3 ;;
+    \?) printf 'UNKNOWN - invalid option: -%s\n' "$OPTARG"; exit 3 ;;
+  esac
+done
+
+if ! is_int "$WARN" || ! is_int "$CRIT"; then
+  printf '%s\n' 'UNKNOWN - warning and critical must be integers'
+  exit 3
+fi
+
+if (( WARN < 0 || CRIT < 0 || WARN >= CRIT || CRIT > 100 )); then
+  printf '%s\n' 'UNKNOWN - thresholds must satisfy 0 <= warning < critical <= 100'
+  exit 3
+fi
+
+case "$MODE" in
+  aggregate|single) ;;
+  *)
+    printf '%s\n' 'UNKNOWN - mode must be aggregate or single'
+    exit 3
+    ;;
+esac
+
+if [[ "$MODE" == "single" ]]; then
+  if [[ -z "$GPU_INDEX" ]] || ! is_int "$GPU_INDEX"; then
+    printf '%s\n' 'UNKNOWN - single mode requires -i <gpu_index>'
+    exit 3
+  fi
+fi
+
+if [[ ! -x "$NVIDIA_SMI" ]]; then
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    NVIDIA_SMI="$(command -v nvidia-smi)"
+  else
+    printf '%s\n' 'UNKNOWN - nvidia-smi not found'
+    exit 3
+  fi
+fi
+
+OUTPUT="$("$NVIDIA_SMI" \
+  --query-gpu=index,name,utilization.gpu,utilization.memory,memory.used,memory.total,temperature.gpu \
+  --format=csv,noheader,nounits 2>&1)"
+RC=$?
+
+if (( RC != 0 )); then
+  printf 'UNKNOWN - nvidia-smi failed: %s\n' "$OUTPUT"
+  exit 3
+fi
+
+if [[ -z "${OUTPUT//[[:space:]]/}" ]]; then
+  printf '%s\n' 'UNKNOWN - no NVIDIA GPUs returned by nvidia-smi'
+  exit 3
+fi
+
+overall_state=0
+matched_count=0
+max_util=-1
+
+declare -a summaries alerts perfdata long_output
+
+while IFS= read -r line; do
+  [[ -z "${line//[[:space:]]/}" ]] && continue
+
+  IFS=',' read -r idx name gpu_util mem_util mem_used mem_total temp <<< "$line"
+
+  idx="$(trim "$idx")"
+  name="$(trim "$name")"
+  gpu_util="$(trim "$gpu_util")"
+  mem_util="$(trim "$mem_util")"
+  mem_used="$(trim "$mem_used")"
+  mem_total="$(trim "$mem_total")"
+  temp="$(trim "$temp")"
+
+  if ! is_int "$idx" || ! is_int "$gpu_util"; then
+    printf 'UNKNOWN - failed to parse line: %s\n' "$line"
+    exit 3
+  fi
+
+  if [[ "$MODE" == "single" && "$idx" != "$GPU_INDEX" ]]; then
+    continue
+  fi
+
+  (( matched_count += 1 ))
+
+  if (( gpu_util > max_util )); then
+    max_util=$gpu_util
+  fi
+
+  state=0
+  if (( gpu_util >= CRIT )); then
+    state=2
+    alerts+=("gpu${idx}(${name})=${gpu_util}%")
+  elif (( gpu_util >= WARN )); then
+    state=1
+    alerts+=("gpu${idx}(${name})=${gpu_util}%")
+  fi
+
+  if (( state > overall_state )); then
+    overall_state=$state
+  fi
+
+  summary="gpu${idx}(${name}) util=${gpu_util}%"
+
+  if is_int "${mem_util:-}"; then
+    summary+=" memutil=${mem_util}%"
+  else
+    summary+=" memutil=?"
+  fi
+
+  if is_int "${mem_used:-}" && is_int "${mem_total:-}"; then
+    summary+=" vram=${mem_used}/${mem_total}MB"
+  elif [[ -n "${mem_used:-}" || -n "${mem_total:-}" ]]; then
+    summary+=" vram=${mem_used:-?}/${mem_total:-?}MB"
+  fi
+
+  if is_int "${temp:-}"; then
+    summary+=" temp=${temp}C"
+  else
+    summary+=" temp=?C"
+  fi
+
+  summaries+=("$summary")
+  long_output+=("$summary")
+
+  perfdata+=("gpu${idx}_util=${gpu_util}%;${WARN};${CRIT};0;100")
+
+  if is_int "${mem_util:-}"; then
+    perfdata+=("gpu${idx}_memutil=${mem_util}%;;;0;100")
+  fi
+  if is_int "${mem_used:-}" && is_int "${mem_total:-}"; then
+    perfdata+=("gpu${idx}_mem_used=${mem_used}MB;;;0;${mem_total}")
+  fi
+  if is_int "${temp:-}"; then
+    perfdata+=("gpu${idx}_temp=${temp};;;;")
+  fi
+done <<< "$OUTPUT"
+
+if (( matched_count == 0 )); then
+  if [[ "$MODE" == "single" ]]; then
+    printf 'UNKNOWN - GPU index %s not found\n' "$GPU_INDEX"
+  else
+    printf '%s\n' 'UNKNOWN - no matching GPUs found'
+  fi
+  exit 3
+fi
+
+FULL_SUMMARY="$(join_by '; ' "${summaries[@]}")"
+ALERT_SUMMARY="$(join_by ', ' "${alerts[@]}")"
+PERFDATA="$(join_by ' ' "${perfdata[@]}")"
+
+case "$overall_state" in
+  0)
+    if [[ "$MODE" == "single" ]]; then
+      TEXT="OK - GPU${GPU_INDEX} utilization OK (${max_util}%)"
+      long_output=("Mode: single (GPU${GPU_INDEX})" "${long_output[@]}")
+    else
+      TEXT="OK - GPU utilization OK (max=${max_util}%)"
+      long_output=("Mode: aggregate" "${long_output[@]}")
+    fi
+    ;;
+  1)
+    if [[ "$MODE" == "single" ]]; then
+      TEXT="WARNING - GPU${GPU_INDEX} utilization above warning threshold: ${ALERT_SUMMARY}"
+      long_output=("Mode: single (GPU${GPU_INDEX})" "Offenders: ${ALERT_SUMMARY}" "${long_output[@]}")
+    else
+      TEXT="WARNING - GPU utilization above warning threshold: ${ALERT_SUMMARY}"
+      long_output=("Mode: aggregate" "Offenders: ${ALERT_SUMMARY}" "${long_output[@]}")
+    fi
+    ;;
+  2)
+    if [[ "$MODE" == "single" ]]; then
+      TEXT="CRITICAL - GPU${GPU_INDEX} utilization above critical threshold: ${ALERT_SUMMARY}"
+      long_output=("Mode: single (GPU${GPU_INDEX})" "Offenders: ${ALERT_SUMMARY}" "${long_output[@]}")
+    else
+      TEXT="CRITICAL - GPU utilization above critical threshold: ${ALERT_SUMMARY}"
+      long_output=("Mode: aggregate" "Offenders: ${ALERT_SUMMARY}" "${long_output[@]}")
+    fi
+    ;;
+  *)
+    TEXT='UNKNOWN - unexpected state'
+    overall_state=3
+    ;;
+esac
+
+if [[ -n "$PERFDATA" ]]; then
+  FIRST_LINE="${TEXT} | ${PERFDATA}"
+else
+  FIRST_LINE="${TEXT}"
+fi
+
+printf '%s\n' "$FIRST_LINE"
+
+if ((${#long_output[@]} > 0)); then
+  printf '%s\n' "${long_output[@]}"
+fi
+
+exit "$overall_state"

--- a/lib/facter/nagios_nvidia_gpu.rb
+++ b/lib/facter/nagios_nvidia_gpu.rb
@@ -1,0 +1,7 @@
+# Creates nagios_nvidia_gpu if nvidia-smi binary is found
+
+if File.executable?('/bin/nvidia-smi') || File.executable?('/usr/bin/nvidia-smi')
+  Facter.add('nagios_nvidia_gpu') do
+    setcode { true }
+  end
+end

--- a/manifests/check/nvidia_gpu.pp
+++ b/manifests/check/nvidia_gpu.pp
@@ -1,0 +1,73 @@
+class nagios::check::nvidia_gpu (
+  Enum['present','absent'] $ensure                   = 'present',
+  Optional[String]         $args                     = '',
+  Integer                  $warning                  = 70,
+  Integer                  $critical                 = 90,
+  Enum['aggregate','single'] $mode                  = 'aggregate',
+  Optional[Integer]        $gpu_index                = undef,
+  Optional[String]         $check_title              = $::nagios::client::host_name,
+  Optional[String]         $service_description      = undef,
+  Optional[String]         $servicegroups            = undef,
+  Optional[String]         $check_period             = $::nagios::client::service_check_period,
+  Optional[String]         $contact_groups           = $::nagios::client::service_contact_groups,
+  Optional[String]         $first_notification_delay = $::nagios::client::service_first_notification_delay,
+  Optional[String]         $max_check_attempts       = $::nagios::client::service_max_check_attempts,
+  Optional[String]         $notification_period      = $::nagios::client::service_notification_period,
+  Optional[String]         $use                      = $::nagios::client::service_use,
+) inherits ::nagios::client {
+
+  if $mode == 'single' and $gpu_index == undef and $args !~ /(^|\s)-i(\s|$)/ {
+    fail('nagios::check::nvidia_gpu: gpu_index must be set when mode=single unless -i is already provided in args')
+  }
+
+  # Build defaults unless explicitly overridden in $args
+  if $args !~ /(^|\s)-w(\s|$)/ { $arg_w = "-w ${warning} " } else { $arg_w = '' }
+  if $args !~ /(^|\s)-c(\s|$)/ { $arg_c = "-c ${critical} " } else { $arg_c = '' }
+  if $args !~ /(^|\s)-m(\s|$)/ { $arg_m = "-m ${mode} " }     else { $arg_m = '' }
+
+  if $gpu_index != undef and $args !~ /(^|\s)-i(\s|$)/ {
+    $arg_i = "-i ${gpu_index} "
+  } else {
+    $arg_i = ''
+  }
+
+  $fullargs = strip("${arg_w}${arg_c}${arg_m}${arg_i}${args}")
+
+  if $service_description == undef {
+    if $mode == 'single' and $gpu_index != undef {
+      $real_service_description = "nvidia_gpu_${gpu_index}"
+    } else {
+      $real_service_description = 'nvidia_gpu'
+    }
+  } else {
+    $real_service_description = $service_description
+  }
+
+  file { '/usr/lib64/nagios/plugins/check_nvidia_gpu':
+    ensure => $ensure,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+    source => "puppet:///modules/${module_name}/scripts/check_nvidia_gpu",
+  }
+
+  nagios::client::nrpe_file { 'check_nvidia_gpu':
+    ensure  => $ensure,
+    args    => $fullargs,
+    require => File['/usr/lib64/nagios/plugins/check_nvidia_gpu'],
+    plugin  => 'check_nvidia_gpu',
+  }
+
+  nagios::service { "check_nvidia_gpu_${check_title}":
+  ensure                   => $ensure,
+  check_command            => 'check_nrpe_nvidia_gpu',
+  service_description      => $real_service_description,
+  servicegroups            => $servicegroups,
+  check_period             => $check_period,
+  contact_groups           => $contact_groups,
+  first_notification_delay => $first_notification_delay,
+  notification_period      => $notification_period,
+  max_check_attempts       => $max_check_attempts,
+  use                      => $use,
+  }
+}

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -205,6 +205,7 @@ class nagios::client (
     if getvar('::virtual') == 'physical' {  class { '::nagios::check::cpu_temp': } }
     if getvar('::nagios_elasticsearch') {  class { '::nagios::check::elasticsearch': } }
     if getvar('::nagios_fluentbit') {  class { '::nagios::check::fluentbit': } }
+    if getvar('::nagios_nvidia_gpu') {  class { '::nagios::check::nvidia_gpu': } }
     if getvar('::nagios_kafka') {
       class { '::nagios::check::kafka': }
       class { '::nagios::check::kafka_isr': }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1036,6 +1036,9 @@ class nagios::server (
   nagios_command { 'check_nrpe_fluentbit_health':
     command_line => "${nrpe} -c check_fluentbit_health",
   }
+  nagios_command { 'check_nrpe_nvidia_gpu':
+    command_line => "${nrpe} -c check_nvidia_gpu",
+  }
   nagios_command { 'check_nrpe_ssd':
     command_line => "${nrpe} -c check_ssd",
   }


### PR DESCRIPTION
Added `check_nvidia_gpu` to monitor NVIDIA GPU utilization, memory usage, and temperature via `nvidia-smi`.

Features:
- Monitors GPU utilization with configurable WARN/CRIT thresholds
- Supports 'aggregate' (worst-state) and 'single' (specific index) modes
- Handles NRPE multi-line output correctly (perfdata on line 1)
- Appends detailed VRAM/temp metrics to long output for context